### PR TITLE
Update requirements.txt to use older versions of pandas and altair

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 seaborn==0.11.2
 streamlit==1.10.0
+altair<5
+pandas<2


### PR DESCRIPTION
Recently, altair version 5 and pandas version 2 were released with breaking changes for seaborn 0.11.2.  Therefore, the requirements.txt has been updated to use the older versions of these modules.