### PR TITLE
DSE-52110: upgrade Python 3.9 → 3.12

### DIFF
--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -7,7 +7,7 @@ date: "2022-03-24"
 
 runtimes:
   - editor: PBJ Workbench
-    kernel: Python 3.9
+    kernel: Python 3.12
     edition: Standard
 
 tasks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-altair<5 #need to pin altair version when using steamlit<1.23.0
-seaborn==0.11.2
-streamlit==1.10.0
-pandas<2 #need to pin pandas version for seaborn
+altair==5.4.1
+seaborn==0.13.2
+streamlit==1.39.0
+pandas==2.2.2


### PR DESCRIPTION
Verified by deploying the AMP with the changes from the PR

<img width="1410" height="153" alt="Screenshot 2026-03-25 at 5 37 13 PM" src="https://github.com/user-attachments/assets/91d2faea-725a-44b5-abb9-e3af7a0f8919" />